### PR TITLE
Plasma shape in polar coordinates

### DIFF
--- a/src/karhu/cli/inference_from_helena.py
+++ b/src/karhu/cli/inference_from_helena.py
@@ -2,28 +2,19 @@
 An example python script for running KARHU from a HELENA directory and writing the result to a file. 
 """
 import argparse 
-from karhu.utils_helena import get_model_input
+from karhu.utils_helena import load_from_helena
 from karhu.models import load_model
 from karhu.utils_input import scale_model_input, scale_model_output
 
 import torch
 
-WP     = torch.float32 #TODO: will this change in future? 
+WP     = torch.float32  # TODO: will this change in future? 
 DEVICE = 'cuda' if torch.cuda.is_available() else "cpu"
     
-def main(model_dir:str, helena_dir: str):
+def main(model_dir: str, helena_dir: str):
     model, scaling_params = load_model(model_dir)
     model = model.to(device=DEVICE, dtype=WP)
-    p, q, rbphi, vy, bmag, rmag = get_model_input(helena_dir)
-
-    x = [torch.tensor(p, dtype=WP).unsqueeze(0).unsqueeze(0), 
-        torch.tensor(q, dtype=WP).unsqueeze(0).unsqueeze(0), 
-        torch.tensor(rbphi, dtype=WP).unsqueeze(0).unsqueeze(0), 
-        torch.tensor(vy, dtype=WP).unsqueeze(0).unsqueeze(0), 
-        torch.tensor(bmag, dtype=WP).unsqueeze(0), 
-        torch.tensor(rmag, dtype=WP).unsqueeze(0), 
-        ]
-    print(x)
+    x = load_from_helena(helena_dir)
     x = scale_model_input(x, scaling_params)
     with torch.no_grad(): 
         y = model(*x)

--- a/src/karhu/common.py
+++ b/src/karhu/common.py
@@ -41,3 +41,151 @@ def forward_pass(x: list[torch.tensor], model, scaling_params) -> torch.tensor:
         y_pred = model(*x)
     y_pred = descale_minmax(y_pred.item(), *scaling_params["growthrate"])
     return y_pred
+
+
+def get_polar_from_rz(r_vals, z_vals, r0=0.0, z0=0.0, amin=1.0, symmetric=False):
+    """
+    Convert (R, Z) boundary coordinates to polar coordinates (rho, theta)
+    relative to the boundary center (r0, z0).
+
+    Handles both symmetric and asymmetric boundaries:
+    - If symmetric (self.symmetric=True): input contains only the top half,
+        and the function mirrors it to produce a full 0-2pi contour.
+    - If asymmetric: uses the full input directly.
+
+    Parameters
+    ----------
+    r_vals : array_like
+        R (major radius) coordinates of the boundary.
+    z_vals : array_like
+        Z (vertical) coordinates of the boundary.
+
+    Returns
+    -------
+    rho : ndarray
+        Normalized radius rho = sqrt((R - r0)^2 + (Z - z0)^2) / a_min
+    theta : ndarray
+        Poloidal angle theta in radians, from 0 to 2pi.
+    """
+    r_vals = np.asarray(r_vals)
+    z_vals = np.asarray(z_vals)
+
+    # Mirror the top half if the plasma is symmetric
+    if symmetric:
+        # Mirror across the midplane (z0)
+        r_mirror = np.copy(r_vals[::-1])
+        z_mirror = 2 * z0 - z_vals[::-1]
+
+        # Combine top (input) and mirrored bottom
+        r_vals = np.concatenate([r_vals, r_mirror[1:]])  # avoid duplicate at midplane
+        z_vals = np.concatenate([z_vals, z_mirror[1:]])
+
+    # Compute normalized radius and poloidal angle
+    rho = np.sqrt((r_vals - r0)**2 + (z_vals - z0)**2) / amin
+    theta = np.arctan2(z_vals - z0, r_vals - r0)
+
+    # Convert theta range from (-pi, pi] → [0, 2pi)
+    theta = np.mod(theta, 2 * np.pi)
+
+    # Sort points by increasing theta to ensure continuous boundary
+    order = np.argsort(theta)
+    return rho[order], theta[order]
+
+
+def get_rz_from_fourier(realfour, imagfour, r0=0.0, z0=0.0, amin=1.0):
+    """
+    Reconstruct the boundary (R(theta), Z(theta)) using Fourier coefficients.
+
+    r(theta) = a0/2 + Σ [a_m cos(mtheta) + b_m sin(mtheta)],  m = 1..N/2
+    R(theta) = r0 + a_min * r(theta) * cos(theta)
+    Z(theta) = z0 + a_min * r(theta) * sin(theta)
+
+    A high-resolution uniform grid in theta ∈ [0, 2pi] is used to evaluate
+    the boundary.
+
+    Parameters
+    ----------
+    realfour : array_like
+        Real Fourier coefficients (a_m). The first element corresponds
+        to the m = 0 mode.
+    imagfour : array_like
+        Imaginary Fourier coefficients (b_m).
+    r0 : float, optional
+        Radial offset of the boundary center. Default is 0.0.
+    z0 : float, optional
+        Vertical offset of the boundary center. Default is 0.0.
+    amin : float, optional
+        Minor radius. Scaling factor applied to the reconstructed radial function.
+        Default is 1.0.
+
+    Returns
+    -------
+    rf : ndarray
+        Radial coordinate R(θ) evaluated on a fine θ grid.
+    zf : ndarray
+        Vertical coordinate Z(θ) evaluated on a fine θ grid.
+    """
+
+    # High-resolution grid
+    thetafine = np.arange(2048) / (2048 - 1.0) * 2.0 * np.pi
+
+    nf = len(realfour) * 2
+    nph = np.matrix(range(int(nf / 2)))
+    theta = np.matrix(thetafine)
+
+    # Compute cosine and sine terms
+    cm = np.cos(nph.transpose() * theta)
+    sm = np.sin(nph.transpose() * theta)
+
+    # Adjust a0 term
+    realf = np.matrix(realfour)
+    realf[0, 0] = realf[0, 0] / 2
+    imagf = np.matrix(imagfour)
+
+    # Reconstruct normalized radius
+    rad = amin * (realf * cm + imagf * sm)
+
+    # Convert back to Cartesian
+    rf = r0 + np.asarray(rad) * np.cos(thetafine)
+    zf = z0 + np.asarray(rad) * np.sin(thetafine)
+    
+    return rf, zf
+
+
+def get_polar_from_fourier(realfour, imagfour):
+    """
+    Convert Fourier coefficients to polar coordinates.
+
+    This function computes the real-space components from the given
+    real and imaginary Fourier coefficients, then converts those
+    components into polar coordinates.
+
+    Parameters
+    ----------
+    realfour : array_like
+        Real part of the Fourier coefficients.
+    imagfour : array_like
+        Imaginary part of the Fourier coefficients.
+
+    Returns
+    -------
+    rho : array_like
+        Radial magnitude corresponding to the Fourier components.
+    theta : array_like
+        Angular coordinate (in radians) corresponding to the Fourier components.
+    """
+    r, z = get_rz_from_fourier(realfour, imagfour)
+    rho, theta = get_polar_from_rz(r, z)
+    return rho, theta
+
+
+def cart2pol(x, y):
+    rho = np.sqrt(x**2 + y**2)
+    theta = np.arctan2(y, x)
+    return(rho, theta)
+
+
+def pol2cart(rho, theta):
+    x = rho * np.cos(theta)
+    y = rho * np.sin(theta)
+    return(x, y)

--- a/src/karhu/utils_helena.py
+++ b/src/karhu/utils_helena.py
@@ -3,7 +3,10 @@ import math
 
 import numpy as np 
 import f90nml 
+import torch
+
 from karhu.utils_input import interpolate_profile
+from karhu.common import get_polar_from_rz
 
 
 def read_fort20_beta_section(filename: str) -> tuple[float]:
@@ -269,49 +272,71 @@ def get_eps_from_f20(filename_f20):
     return eps
 
 
-def get_model_input(heldir: str) -> list[np.ndarray]:
+def load_from_helena(helena_directory: str) -> list[np.ndarray]:
     """
     Prepares the inputs to KARHU. 
-    -- Reads relevant data from HELENA
-    -- Interpolates onto the common axis (psi/rbndry) used for KARHU
+    - Reads relevant data from HELENA
+    - Interpolates onto the common axis (psi/rbndry) used for KARHU.
+    - Converts data to tensors
     
-    Data must still be converted to torch tensors before passing to model
+    Profiles come from mapping file (fort.12) --> input into MISHKA
+    They are normalised such that p(psi=0.0) = 1,
+
     Args:
-        heldir (str): Path to the directory where fort.10/fort.12/fort.20 should be
+        helena_directory (str):
+            Path to the directory where fort.10/fort.12/fort.20 should be
     Returns:
         list: List of numpy arrays containing the model input.
     """
-    filename_f10 = os.path.join(heldir, "fort.10")
-    filename_f12 = os.path.join(heldir, "fort.12")
-    filename_f20 = os.path.join(heldir, "fort.20")
+    fname_f10: str = os.path.join(helena_directory, "fort.10")
+    fname_f12: str = os.path.join(helena_directory, "fort.12")
+    fname_f20: str = os.path.join(helena_directory, "fort.20")
 
+    f12data = get_f12_data(fname_f12, variables=["CS", "QS", "RADIUS", "P0", "RBPHI", "VX", "VY"])
+    f10data = f90nml.read(fname_f10)
+   
+    RADIUS: float = f12data["RADIUS"]                             # geometric axis minor radius?? 
+    # rest are numpy arrays
+    P, RBPHI, QS = f12data["P0"], f12data["RBPHI"], f12data["QS"] # normalised profiles
+    CS = f12data["CS"]**2                                         # Helena uses sqrt(psi) grid, i.e., CS**2 = PSI, CS**4 = PSI**2,
+    rbdry, zbdry = f12data["VX"], f12data["VY"]                 # Boundary in R, Z
+
+    # geometric axis magnetic field strength
+    *_, B_0H = read_fort20_beta_section(fname_f20)
+
+    epsilon = f10data["phys"]["eps"]  # inv. aspect ratio
+    R_vac   = f10data["phys"]["rvac"] # major radius in vaccuum
+    B_vac   = f10data["phys"]["bvac"]
+    R_mag   = (epsilon / RADIUS) * R_vac
+    B_mag   = B_vac / B_0H
+
+    pressure_karhu = P
+    rbphi_karhu    = RBPHI
+    q_karhu = QS
+
+    rbndry_karhu = rbdry
+    zbndry_karhu = zbdry
     
-    helena_input = f90nml.read(filename_f10)
-    out = get_f12_data(
-        filename_f12, variables=["CS", "QS", "RADIUS", "P0", "RBPHI", "VX", "VY"])
-
-    CS, P, RBPHI, QS = out["CS"], out["P0"], out["RBPHI"], out["QS"]
-    VX, VY = out["VX"], out["VY"]
-    RADIUS = out["RADIUS"]
-
-    (_, _, _, _, _, _, _, _, _, _, B0,) = read_fort20_beta_section(filename_f20)
-
-    # Get scaling parameters
-    epsilon = helena_input["phys"]["eps"]  # inverse aspect ratio
-    R_vac = helena_input["phys"]["rvac"]
-    # minor_radius = epsilon * R_vac
-    B_vac = helena_input["phys"]["bvac"]
-    R_mag = (epsilon / RADIUS) * R_vac
-    B_mag = B_vac / B0
-
-    # New grid
-    n_profile_points = 64
-    x_1  = np.linspace(1e-5, 1, n_profile_points) ** (1 / 4)
-    vx_1 = np.linspace(-0.999, 0.999, n_profile_points)
-    x_0 = CS
-    p_1 = interpolate_profile(x_0, P, x_1)
-    qs_1 = interpolate_profile(x_0, QS, x_1)
-    rbphi_1 = interpolate_profile(x_0, RBPHI, x_1)
-    vy_1 = interpolate_profile(x_0=VX, y_0=VY, x_1=vx_1)
-    return [p_1, qs_1, rbphi_1, vy_1, B_mag, R_mag]
     
+    ninterp = 64
+    KARHU_PSIN_AXIS = np.linspace(1e-5, 1.0, ninterp) ** 0.5
+    KARHU_VX_AXIS   = np.linspace(-0.999, 0.999, ninterp)   # TODO/FIXME the interpolation axis is flawed here, since HELENA may not go to 0.999, 0.999...
+    KARHU_THETA_AXIS = np.linspace(1e-5, 2*np.pi, ninterp)
+
+    pressure_karhu = interpolate_profile(CS, pressure_karhu, KARHU_PSIN_AXIS)
+    rbphi_karhu = interpolate_profile(CS, rbphi_karhu, KARHU_PSIN_AXIS)
+    q_karhu = interpolate_profile(CS, q_karhu, KARHU_PSIN_AXIS)
+
+    # Construct boundary in polar coordinates
+    symmetric = f10data["shape"]["ias"] ==  0
+    rhobndry, thetabndry = get_polar_from_rz(r_vals=rbdry, z_vals=zbdry, symmetric=symmetric)
+    rhobndry_karhu = interpolate_profile(x_0=thetabndry, y_0=rhobndry, x_1=KARHU_THETA_AXIS)
+
+    x = [torch.tensor(pressure_karhu, dtype=torch.float32).unsqueeze(0).unsqueeze(0),
+         torch.tensor(q_karhu, dtype=torch.float32).unsqueeze(0).unsqueeze(0),
+         torch.tensor(rbphi_karhu, dtype=torch.float32).unsqueeze(0).unsqueeze(0),
+         torch.tensor(rhobndry_karhu, dtype=torch.float32).unsqueeze(0).unsqueeze(0),
+         torch.tensor(B_mag, dtype=torch.float32).unsqueeze(0),
+         torch.tensor(R_mag, dtype=torch.float32).unsqueeze(0),
+    ]
+    return x

--- a/src/karhu/utils_input.py
+++ b/src/karhu/utils_input.py
@@ -83,33 +83,3 @@ def scale_model_output(y, scaling_params):
         pass
     growthrate = descale_minmax(y, scaling_params["growthrate"][0], scaling_params["growthrate"][1])
     return growthrate
-
-
-def convert_profiles_si_to_dimensionless(pressure, rbphi, rbdry, zbdry,
-                                         radius: float, R_mag: float, eps: float, B_mag: float):
-    """
-    KARHU/MISHKA dimensionless normalisation from SI units
-    KARHU_PRESSURE = PRESSURE_SI / (B_magaxis**2 / mu_0)
-    KARHU_RBPHI    = RBPHI_SI    / (R_magaxis * B_magaxis)
-    KARHU_RBDRY    = RBDRY_SI    / (radius * R_magaxis) - 1.0 / eps
-    KARHU_ZBDRY    = ZBDRY_SI    / (radius * R_magaxis)
-    KARHU_Q        = Q
-
-    where
-        PRESSURE_SI [N / m^2] plasma pressure          (defined on PSIN)
-        RBPHI_SI    [Tm]      poloidal flux function   (defined on PSIN)
-        Q           []        q-profile, safety factor (defined on PSIN)
-        RBDRY_SI    [m]       R/X coordinates of plasma boundary
-        ZBDRY_SI    [m]       Z/Y coordinates of plasma boundary
-        B_magaxis   [T]       magnetic field strength at the magnetic axis
-        R_magaxis   [m]       major radius at the magnetic axis
-        eps         [-]       inverse aspect ratio of the plasma boundary
-        radius      [-]       dimensionless value, used to scale R/X boundary between -1 and 1
-                                is equal to eps * R_geom / R_magaxis,  
-                                where R_geom is the geometric axis
-    """
-    pressure_karhu = pressure / (B_mag**2 / MU_0)
-    rbphi_karhu    = rbphi     / (R_mag * B_mag)
-    rbndry_karhu   = rbdry    / (radius * R_mag) - 1.0 / eps
-    zbndry_karhu   = zbdry    / (radius * R_mag)
-    return pressure_karhu, rbphi_karhu, rbndry_karhu, zbndry_karhu

--- a/tests/test_inference_helena.py
+++ b/tests/test_inference_helena.py
@@ -11,9 +11,12 @@ import numpy as np
 import torch
 
 from karhu.utils_input import (
-    interpolate_profile, minmax,
+    scale_model_input,
+    interpolate_profile,
+    minmax,
     scale_model_output)
-from karhu.utils_helena import get_f12_data, read_fort20_beta_section
+from karhu.utils_helena import (
+    load_from_helena, get_f12_data, read_fort20_beta_section)
 from karhu.models import load_model
 
 TESTDATADIR = os.path.dirname(__file__)
@@ -21,99 +24,13 @@ TESTDATADIR = os.path.dirname(__file__)
 helena_directory = os.path.join(TESTDATADIR, "data", "helena_jet")
 models_directory = os.path.join(TESTDATADIR, "..", "model", "jet_2H")
 
-
-def load_data_from_helena_directory(helena_directory: str) -> dict[str, np.ndarray]:
-    """
-    Read the q(psi), pressure(psi), rbphi(psi), boundary
-    And interpolate onto the axis that the model was trained on.
-    Stack profiles for [P, Q, RBPHI, BNDRY, B0, R0], where B0 and R0 are scalars.
-
-    """
-
-    fname_f10: str = os.path.join(helena_directory, "fort.10")
-    fname_f12: str = os.path.join(helena_directory, "fort.12")
-    fname_f20: str = os.path.join(helena_directory, "fort.20")
-
-    f12data = get_f12_data(fname_f12, variables=["CS", "QS", "RADIUS", "P0", "RBPHI", "VX", "VY"])
-    f10data = f90nml.read(fname_f10)
-    """
-    Profiles come from mapping file (fort.12) --> input into MISHKA
-    They are normalised such that p(psi=0.0) = 1,
-    """
-    RADIUS: float = f12data["RADIUS"]                             # geometric axis minor radius??
-    # rest are numpy arrays
-    P, RBPHI, QS = f12data["P0"], f12data["RBPHI"], f12data["QS"] # normalised profiles
-    CS = f12data["CS"]                                            # Helena uses sqrt(psi) grid, i.e., CS**2 = PSI, CS**4 = PSI**2,
-    rbndry, zbndry = f12data["VX"], f12data["VY"]                 # Boundary in R, Z
-
-    # geometric axis magnetic field strength
-    *_, B_0H = read_fort20_beta_section(fname_f20)
-
-    epislon = f10data["phys"]["eps"]   # inv. aspect ratio
-    R_vac   = f10data["phys"]["rvac"]  # major radius in vaccuum
-    B_vac   = f10data["phys"]["bvac"]
-
-    """ Normalisation parameters for HELENA/MISHKA """
-    R0   = (epislon / RADIUS) * R_vac
-    B0   = B_vac / B_0H                 # TODO: explain
-
-    """
-    Interpolation onto karhu grid
-    """
-    NPOINTS = 64
-    new_grid = np.linspace(1e-5, 1, NPOINTS) ** (1 / 4)  # this uniform grid in PSI**2, which means to get back to CS points we need to do power 1/4
-    old_grid = CS
-    [P_interp, QS_interp, RBPHI_interp] = interpolate_profiles_onto_grid(new_grid, old_grid, profiles=[P, QS, RBPHI])
-
-    # Boundary grid:
-    new_grid_vx = np.linspace(-0.999, 0.999, NPOINTS)
-    [VY_interp] = interpolate_profiles_onto_grid(newgrid=new_grid_vx, oldgrid=rbndry, profiles=[zbndry])
-
-    # model_input = np.stack([P_interp, QS_interp, RBPHI_interp, VY_interp, B0, R0])
-    model_input = dict(p=P_interp, qs=QS_interp, rbphi=RBPHI_interp, shape=VY_interp, b_mag=B0, r_mag=R0)
-    return model_input
-
-
-def interpolate_profiles_onto_grid(newgrid, oldgrid, profiles: list):
-    new_profiles = []
-    for _prof in profiles:
-        new_prof = interpolate_profile(oldgrid, _prof, newgrid)
-        new_profiles.append(new_prof)
-    return new_profiles
-
-
-def scale_inputs(inputs: dict[str, np.ndarray | float], scaling_dict: dict[str, tuple[float, float]]) -> dict[str, np.ndarray | float]:
-    inputs_scaled = {}
-    for key, value in inputs.items():
-        inputs_scaled[key] = minmax(value, *scaling_dict[key])
-    return inputs_scaled
-
-
-def to_tensor(inputs: dict[str, np.ndarray | float]) -> dict[str, torch.Tensor]:
-    inputs_tensor = {}
-    for key, value in inputs.items():
-        value_tensor = torch.tensor(value, dtype=torch.float32)
-        if isinstance(value, np.ndarray):
-            value_tensor = value_tensor.unsqueeze(0).unsqueeze(0)
-        elif isinstance(value, float):
-            value_tensor = value_tensor.unsqueeze(0)
-        inputs_tensor[key] = value_tensor
-    return inputs_tensor
-
-
 @pytest.mark.parametrize("heldir,modeldir", [(helena_directory, models_directory)])
 def test_inference(heldir, modeldir):
-    model_inputs = load_data_from_helena_directory(heldir)
     model, scaling_params = load_model(model_dir=modeldir)
-    model_inputs = scale_inputs(model_inputs, scaling_params)
-    model_inputs = to_tensor(model_inputs)
-    y_pred_norm = model(
-        input_p=model_inputs["p"],
-        input_qs=model_inputs["qs"],
-        input_rbphi=model_inputs["rbphi"],
-        input_shape=model_inputs["shape"],
-        b_mag=model_inputs["b_mag"],
-        r_mag=model_inputs["r_mag"])
+    model_inputs = load_from_helena(heldir)
+    model_inputs = scale_model_input(model_inputs, scaling_params)
+    with torch.no_grad(): 
+        y_pred_norm = model(*model_inputs)
     y_pred = scale_model_output(y_pred_norm, scaling_params)
-    print(f"KARHU predicted growthrate: {y_pred}")
+    print(f"Predicted growth rate: {y_pred:.4f}")
     assert y_pred > 0.0

--- a/tests/test_normalisation_and_inference_eqdsk.py
+++ b/tests/test_normalisation_and_inference_eqdsk.py
@@ -36,8 +36,8 @@ from karhu.utils_input import (
     interpolate_profile,
     scale_model_input,
     descale_minmax)
-from karhu.utils_helena import get_f12_data, read_fort20_beta_section
-
+from karhu.utils_helena import get_f12_data, read_fort20_beta_section, load_from_helena
+from karhu.utils_eqdsk import load_from_eqdsk
 
 TESTDIR = os.path.dirname(__file__)
 TESTDATADIR = os.path.join(TESTDIR, "data")
@@ -144,110 +144,8 @@ def test_inference_from_eqdsk(eqdskpath):
 
     y_pred = descale_minmax(y_pred.item(), *scaling_params["growthrate"])
     assert y_pred >= 0.0  # TODO: have some benchmark cases?
-    print(y_pred)
+    print(f"Predicted growth rate: {y_pred:.4f}")
 
-
-def load_from_eqdsk(eqdskpath):
-    eqdsk = load_eqdsk(eqdskpath)
-    psin1d = np.linspace(0, 1.0, eqdsk.nx)
-    R_mag  = eqdsk.rmagx
-    B_mag  = eqdsk.fpol[0] / eqdsk.rmagx
-
-    R_geom = (eqdsk.rbdry.max() + eqdsk.rbdry.min()) / 2.0
-    a_geom = (eqdsk.rbdry.max() - eqdsk.rbdry.min()) / 2.0
-    eps    = a_geom / R_geom
-
-    radius = eps * R_geom / R_mag
-    pressure_karhu, rbphi_karhu, rbndry_karhu, zbndry_karhu = convert_profiles_si_to_dimensionless(eqdsk.pressure, eqdsk.fpol, eqdsk.rbdry, eqdsk.zbdry,
-                                                                                                   radius, R_mag, eps, B_mag, )
-   
-    q_karhu = eqdsk.qpsi
-   
-    ninterp = 64
-    KARHU_PSIN_AXIS = np.linspace(1e-5, 1.0, ninterp) ** 0.5
-    KARHU_VX_AXIS   = np.linspace(-0.999, 0.999, ninterp)   # TODO/FIXME the interpolation axis is flawed here, since HELENA may not go to 0.999, 0.999...
-
-    pressure_karhu = interpolate_profile(psin1d, pressure_karhu, KARHU_PSIN_AXIS)
-    rbphi_karhu = interpolate_profile(psin1d, rbphi_karhu, KARHU_PSIN_AXIS)
-    q_karhu = interpolate_profile(psin1d, q_karhu, KARHU_PSIN_AXIS)
-    q_karhu = abs(q_karhu)  # TODO/FIXME: Are the q-s normalised? 
-
-    # FIXME: version 1.0 of the model only takes top half of the boundary
-    reduced_bndry = zbndry_karhu > 0.0
-    rbndry_top, zbndry_top = rbndry_karhu[reduced_bndry], zbndry_karhu[reduced_bndry]
-    sorted_idx = np.argsort(rbndry_top)
-    rbndry_karhu, zbndry_karhu = rbndry_top[sorted_idx], zbndry_top[sorted_idx]
-    zbndry_karhu = interpolate_profile(rbndry_karhu, zbndry_karhu, KARHU_VX_AXIS)
-
-    x = [
-        torch.tensor(pressure_karhu, dtype=torch.float32).unsqueeze(0).unsqueeze(0),
-        torch.tensor(q_karhu, dtype=torch.float32).unsqueeze(0).unsqueeze(0),
-        torch.tensor(rbphi_karhu, dtype=torch.float32).unsqueeze(0).unsqueeze(0),
-        torch.tensor(zbndry_karhu, dtype=torch.float32).unsqueeze(0).unsqueeze(0),
-        torch.tensor(B_mag, dtype=torch.float32).unsqueeze(0),
-        torch.tensor(R_mag, dtype=torch.float32).unsqueeze(0),
-    ]
-    return x
-
-
-def load_from_helena(helena_directory):
-    fname_f10: str = os.path.join(helena_directory, "fort.10")
-    fname_f12: str = os.path.join(helena_directory, "fort.12")
-    fname_f20: str = os.path.join(helena_directory, "fort.20")
-
-    f12data = get_f12_data(fname_f12, variables=["CS", "QS", "RADIUS", "P0", "RBPHI", "VX", "VY"])
-    f10data = f90nml.read(fname_f10)
-   
-    """
-    Profiles come from mapping file (fort.12) --> input into MISHKA
-    They are normalised such that p(psi=0.0) = 1,
-    """
-    RADIUS: float = f12data["RADIUS"]                             # geometric axis minor radius?? 
-    # rest are numpy arrays
-    P, RBPHI, QS = f12data["P0"], f12data["RBPHI"], f12data["QS"] # normalised profiles
-    CS = f12data["CS"]**2                                         # Helena uses sqrt(psi) grid, i.e., CS**2 = PSI, CS**4 = PSI**2,
-    rbdry, zbdry = f12data["VX"], f12data["VY"]                 # Boundary in R, Z
-
-    # geometric axis magnetic field strength
-    *_, B_0H = read_fort20_beta_section(fname_f20)
-
-    epsilon = f10data["phys"]["eps"]  # inv. aspect ratio
-    R_vac   = f10data["phys"]["rvac"] # major radius in vaccuum
-    B_vac   = f10data["phys"]["bvac"]
-    R_mag   = (epsilon / RADIUS) * R_vac
-    B_mag   = B_vac / B_0H
-
-    pressure_karhu = P
-    rbphi_karhu    = RBPHI
-    q_karhu = QS
-
-    rbndry_karhu = rbdry
-    zbndry_karhu = zbdry
-
-    ninterp = 64
-    KARHU_PSIN_AXIS = np.linspace(1e-5, 1.0, ninterp) ** 0.5
-    KARHU_VX_AXIS   = np.linspace(-0.999, 0.999, ninterp)   # TODO/FIXME the interpolation axis is flawed here, since HELENA may not go to 0.999, 0.999...
-
-    pressure_karhu = interpolate_profile(CS, pressure_karhu, KARHU_PSIN_AXIS)
-    rbphi_karhu = interpolate_profile(CS, rbphi_karhu, KARHU_PSIN_AXIS)
-    q_karhu = interpolate_profile(CS, q_karhu, KARHU_PSIN_AXIS)
-
-
-    # FIXME: version 1.0 of the model only takes top half of the boundary
-    reduced_bndry = zbndry_karhu > 0.0
-    rbndry_top, zbndry_top = rbndry_karhu[reduced_bndry], zbndry_karhu[reduced_bndry]
-    sorted_idx = np.argsort(rbndry_top)
-    rbndry_karhu, zbndry_karhu = rbndry_top[sorted_idx], zbndry_top[sorted_idx]
-    zbndry_karhu = interpolate_profile(rbndry_karhu, zbndry_karhu, KARHU_VX_AXIS)
-
-    x = [torch.tensor(pressure_karhu, dtype=torch.float32).unsqueeze(0).unsqueeze(0),
-         torch.tensor(q_karhu, dtype=torch.float32).unsqueeze(0).unsqueeze(0),
-         torch.tensor(rbphi_karhu, dtype=torch.float32).unsqueeze(0).unsqueeze(0),
-         torch.tensor(zbndry_karhu, dtype=torch.float32).unsqueeze(0).unsqueeze(0),
-         torch.tensor(B_mag, dtype=torch.float32).unsqueeze(0),
-         torch.tensor(R_mag, dtype=torch.float32).unsqueeze(0),
-    ]
-    return x
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="freeqdsk has attributes only in versions available for python 3.9 or higher")
 @pytest.mark.parametrize("eqdskpath", eqdsk_testfiles)
@@ -277,5 +175,6 @@ def test_compare_inference_eqdsk_helena(eqdskpath):
         # assert y_pred >= 0.0  # TODO: have some benchmark cases?
         predictions.append(y_pred)
     y_pred_eqdsk, y_pred_helena = predictions
-
+    print(f"Predicted growth rate EQDSK:  {y_pred_eqdsk:.4f}")
+    print(f"Predicted growth rate HELENA: {y_pred_helena:.4f}")
     assert np.isclose(y_pred_eqdsk, y_pred_helena, rtol=0.30, atol=0.1), f"Predictions are off between EQDSK and HELENA ran EQDSK\n EQDSK : {y_pred_eqdsk:.4} \nHELENA: {y_pred_helena:.4}"

--- a/tests/test_normalisation_and_inference_eqdsk.py
+++ b/tests/test_normalisation_and_inference_eqdsk.py
@@ -31,8 +31,8 @@ from freeqdsk import geqdsk
 import torch
 
 from karhu.models import load_model
+from karhu.common import convert_profiles_si_to_dimensionless
 from karhu.utils_input import (
-    convert_profiles_si_to_dimensionless,
     interpolate_profile,
     scale_model_input,
     descale_minmax)


### PR DESCRIPTION
In the previous versions, the plasma shape was given in cartesian coordinates that only included the top half of the boundary. Now, the boundary shape is given in polar coordinates rho(theta), which supports full boundaries.